### PR TITLE
Major bug fixes and meet the most recent messaging protocol for execution

### DIFF
--- a/README.md
+++ b/README.md
@@ -251,6 +251,15 @@ Then:
 ### gophernotes not found
 - Depending on your environment, you may need to manually change the path to the `gophernotes` executable in `kernel/kernel.json` before copying it to `~/.local/share/jupyter/kernels/gophernotes`.  You can put the **full path** to the `gophernotes` executable here, and you shouldn't have any further issues.
 
+### Print outputs string length followed by `<nil>`
+
+Expressions in the top level scope of the notebook are printed out by default. This means that calling
+```go
+fmt.Println("Hello world")
+```
+the string `"Hello world"` is printed and then the two return values `11` and `nil` (bytes written, and error) are also printed.
+
+Instead, if at the top level of the notebook, simply evaluate to a string such as using `fmt.Sprintf` or `"Hello " + "world"`
 
 ### "Kernel error" in a running notebook
 


### PR DESCRIPTION
Fixes #61 - uses the v5 protocol to work with the more recent notebook
implmentation.

Fixes #55 - function declarations were being evaluated and then also
being added back to the body as a broken statement but now properly
remain simply as declarations
- Additionally, functions are no longer declared in multiple files but
rather strategically declared in the main one replacing duplicate
declarations to allow for redefining a function

Fixes #54 - braces are counted so that lines are aware of their starting
scope to properly detect expressions at the top level for printing

Fixes #44 - forwards the output from "go run" in the event of an error

Fixes #15 - declaring a main function (or the __gophernotes magic) will
result in an error saying that declaring them is not allowed

Fixes #14 - stdout is redirected to nil while doing the re-execution of
past code and restore just before executing the code added by the
current cell