### PR TITLE
Live stream output and improved execution semantics

### DIFF
--- a/kernel.go
+++ b/kernel.go
@@ -91,6 +91,10 @@ func runKernel(connectionFile string) {
 	// Set up the "Session" with the replpkg.
 	ir := classic.New()
 
+	// Throw out the error/warning messages that gomacro outputs writes to these streams.
+	ir.Stdout = ioutil.Discard
+	ir.Stderr = ioutil.Discard
+
 	// Parse the connection info.
 	var connInfo ConnectionInfo
 

--- a/kernel_test.go
+++ b/kernel_test.go
@@ -74,24 +74,74 @@ func TestEvaluate(t *testing.T) {
 		Output string
 	}{
 		{[]string{
-			`import "fmt"`,
 			"a := 1",
-			"fmt.Println(a)",
-		}, "1\n"},
+			"a",
+		}, "1"},
 		{[]string{
 			"a = 2",
-			"fmt.Println(a)",
-		}, "2\n"},
+			"a + 3",
+		}, "5"},
 		{[]string{
 			"func myFunc(x int) int {",
 			"    return x+1",
 			"}",
-			`fmt.Println("func defined")`,
-		}, "func defined\n"},
+			"myFunc(1)",
+		}, "2"},
 		{[]string{
 			"b := myFunc(1)",
-			"fmt.Println(b)",
-		}, "2\n"},
+		}, ""},
+		{[]string{
+			"type Rect struct {",
+			"    Width, Height int",
+			"}",
+			"Rect{10, 30}",
+		}, "{10 30}"},
+		{[]string{
+			"type Rect struct {",
+			"    Width, Height int",
+			"}",
+			"&Rect{10, 30}",
+		}, "&{10 30}"},
+		{[]string{
+			"func a(b int) (int, int) {",
+			"    return 2 + b, b",
+			"}",
+			"a(10)",
+		}, "12"},
+		{[]string{
+			`import "errors"`,
+			"func a() (interface{}, error) {",
+			`    return nil, errors.New("To err is human")`,
+			"}",
+			"a()",
+		}, "To err is human"},
+		{[]string{
+			`c := []string{"gophernotes", "is", "super", "bad"}`,
+			"c[:3]",
+		}, "[gophernotes is super]"},
+		{[]string{
+			"m := map[string]int{",
+			`    "a": 10,`,
+			`    "c": 30,`,
+			"}",
+			`m["c"]`,
+		}, "30"},
+		{[]string{
+			"if 1 < 2 {",
+			"    3",
+			"}",
+		}, ""},
+		{[]string{
+			"d := 10",
+			"d++",
+		}, ""},
+		{[]string{
+			"out := make(chan int)",
+			"go func() {",
+			"    out <- 123",
+			"}()",
+			"<-out",
+		}, "123"},
 	}
 
 	t.Logf("Should be able to evaluate valid code in notebook cells.")

--- a/kernel_test.go
+++ b/kernel_test.go
@@ -107,14 +107,14 @@ func TestEvaluate(t *testing.T) {
 			"    return 2 + b, b",
 			"}",
 			"a(10)",
-		}, "12"},
+		}, "12 10"},
 		{[]string{
 			`import "errors"`,
 			"func a() (interface{}, error) {",
 			`    return nil, errors.New("To err is human")`,
 			"}",
 			"a()",
-		}, "To err is human"},
+		}, "<nil> To err is human"},
 		{[]string{
 			`c := []string{"gophernotes", "is", "super", "bad"}`,
 			"c[:3]",
@@ -125,7 +125,7 @@ func TestEvaluate(t *testing.T) {
 			`    "c": 30,`,
 			"}",
 			`m["c"]`,
-		}, "30"},
+		}, "30 true"},
 		{[]string{
 			"if 1 < 2 {",
 			"    3",
@@ -141,7 +141,7 @@ func TestEvaluate(t *testing.T) {
 			"    out <- 123",
 			"}()",
 			"<-out",
-		}, "123"},
+		}, "123 true"},
 	}
 
 	t.Logf("Should be able to evaluate valid code in notebook cells.")

--- a/messages.go
+++ b/messages.go
@@ -301,14 +301,13 @@ type JupyterStreamWriter struct {
 }
 
 // Write implements `io.Writer.Write` by publishing the data via `PublishWriteStream`
-func (writer *JupyterStreamWriter) Write(p []byte) (n int, err error) {
+func (writer *JupyterStreamWriter) Write(p []byte) (int, error) {
 	data := string(p)
-	n = len(p)
+	n := len(p)
 
-	err = writer.receipt.PublishWriteStream(writer.stream, data)
-	if err != nil {
-		n = 0
+	if err := writer.receipt.PublishWriteStream(writer.stream, data); err != nil {
+		return 0, err
 	}
 
-	return
+	return n, nil
 }


### PR DESCRIPTION
This PR more closely follows the semantics of an execution in an ipython notebook.

*   writing to `os.Stdout` or `os.Stderr` sends stream messages to the front end to display this data during the execution and not upon completion
*   only an unrecovered `panic` produces an error
*   ~~the execution_result is the value of the first non-`nil` value of executing an expression at the end of a cell~~
*   the execution_result is all returned values from executing the last expression in a cell unless all values are `nil` in which case there is no execution_result

The above features are tested in `kernel_test.go`

Additionally the PR also implements the heartbeat channel to support long running executions (execution a `time.Sleep` on the main thread) without the front-end disconnecting.

For example:
```go
import (
    "time"
    "fmt"
)
sum := 0
for i := 1; i <= 3; i++ {
    fmt.Printf("+%d\n", i)
    sum += i
    time.Sleep(500 * time.Millisecond)
}
sum
```
Should print out `+1`, `+2`, `+3` separately with 0.5 seconds between prints and result in `Out[_]: 6` 
(And should not result in Jupyter disconnecting with `Dead kernel`)

