### PR TITLE
Pin down tornado and ipykernel version to compatible ones.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -31,7 +31,8 @@ RUN set -x \
     ## jupyter notebook
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     ### fix pyzmq to v16.0.2 as that is what is distributed with py3-zmq
-    && pip3 install jupyter notebook pyzmq==16.0.2 \
+    ### pin down the tornado and ipykernel to compatible versions
+    && pip3 install jupyter notebook pyzmq==16.0.2 tornado==4.5.3 ipykernel==4.8.1 \
     ## install gophernotes
     && GOPATH=/go go install github.com/gopherdata/gophernotes \
     && cp /go/bin/gophernotes /usr/local/bin/ \

--- a/Dockerfile.DS
+++ b/Dockerfile.DS
@@ -32,7 +32,8 @@ RUN set -x \
     ## jupyter notebook 
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     ### fix pyzmq to v16.0.2 as that is what is distributed with py3-zmq
-    && pip3 install jupyter notebook pyzmq==16.0.2 \
+    ### pin down the tornado and ipykernel to compatible versions
+    && pip3 install jupyter notebook pyzmq==16.0.2 tornado==4.5.3 ipykernel==4.8.1 \
     ## install gophernotes
     && export GOPATH=/go \
     && go install github.com/gopherdata/gophernotes \


### PR DESCRIPTION
This PR only changes the dockerfiles and pins down the version of some transitive dependencies of jupyter to compatible ones. It fixes the error mentioned in #137. 