### PR TITLE
Fix display

### DIFF
--- a/display.go
+++ b/display.go
@@ -275,9 +275,12 @@ func (kernel *Kernel) autoRender(mimeType string, arg interface{}, typ xreflect.
 				continue
 			}
 			conv := kernel.ir.Comp.Converter(typ, xtyp)
-			x := base.ValueInterface(conv(reflect.ValueOf(arg)))
-			if x == nil {
-				continue
+			x := arg
+			if conv != nil {
+				x = base.ValueInterface(conv(reflect.ValueOf(x)))
+				if x == nil {
+					continue
+				}
 			}
 			data = fun(data, x)
 		}


### PR DESCRIPTION
`kernel.ir.Comp.Converter(typ, xtyp)` possibly return nil when the arg is image.Image.

```go
import (
    "os"
    "log"
    "image"
    _ "image/png"
)

f, err := os.Open("example.jpg")
if err != nil {
    log.Fatal(err)
}

img, _, err := image.Decode(f)
if err != nil {
    log.Fatal(err)
}
img
```
