### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ $ env GO111MODULE=on go get github.com/gopherdata/gophernotes
 $ mkdir -p ~/.local/share/jupyter/kernels/gophernotes
 $ cd ~/.local/share/jupyter/kernels/gophernotes
 $ cp "$(go env GOPATH)"/pkg/mod/github.com/gopherdata/gophernotes@v0.6.1/kernel/*  "."
+$ chmod +w ./kernel.json # when copied kernel.json has no write permission
 $ sed "s|gophernotes|$(go env GOPATH)/bin/gophernotes|" < kernel.json.in > kernel.json
 ```
 


### PR DESCRIPTION
enhance installation guide for Linux - when copied kernel.json has no write permission

Reproducible from Centos 7.x