### PR TITLE
update Dockerfile.DS to solve series type convertion bugs in kniren/gota

### DIFF
--- a/Dockerfile.DS
+++ b/Dockerfile.DS
@@ -1,4 +1,4 @@
-FROM alpine:3.5
+FROM alpine:3.14
 MAINTAINER dwhitena
 
 # Add gophernotes
@@ -9,21 +9,25 @@ RUN set -x \
     # install python and dependencies
     && apk update \
     && apk --no-cache \
-        --repository http://dl-4.alpinelinux.org/alpine/v3.7/community \
-        --repository http://dl-4.alpinelinux.org/alpine/v3.7/main \
+        --repository http://dl-4.alpinelinux.org/alpine/v3.14/community \
+        --repository http://dl-4.alpinelinux.org/alpine/v3.14/main \
         --arch=x86_64 add \
         python3 \
         su-exec \
         gcc \
         g++ \
         git \
-        py3-zmq \
+        py3-pyzmq \
         pkgconfig \
         zeromq-dev \
         musl-dev \
         mercurial \
-    && pip3 install --upgrade pip==9.0.3 \
-    && cp /usr/bin/python3.6 /usr/bin/python \
+        py3-pip \
+        libffi-dev \
+        python3-dev \
+        mesa-dev \
+    && pip3 install --upgrade pip==21.3.1 \
+    && cp /usr/bin/python3.9 /usr/bin/python \
     ## install Go
     && apk --update-cache --allow-untrusted \
         --repository http://dl-4.alpinelinux.org/alpine/edge/community \
@@ -33,7 +37,7 @@ RUN set -x \
     && ln -s /usr/include/locale.h /usr/include/xlocale.h \
     ### fix pyzmq to v16.0.2 as that is what is distributed with py3-zmq
     ### pin down the tornado and ipykernel to compatible versions
-    && pip3 install jupyter notebook pyzmq==16.0.2 tornado==4.5.3 ipykernel==4.8.1 \
+    && pip3 install jupyter notebook pyzmq tornado ipykernel \
     ## install gophernotes
     && cd /go/src/github.com/gopherdata/gophernotes \
     && export GOPATH=/go \
@@ -44,14 +48,15 @@ RUN set -x \
     && cp -r ./kernel/* ~/.local/share/jupyter/kernels/gophernotes \
     && cd - \
     ## get the relevant Go packages
-    && go get -insecure gonum.org/v1/plot/... \
-    && go get -insecure gonum.org/v1/gonum/... \
-    && go get github.com/kniren/gota/... \
+    && export GOINSECURE=gonum.org/v1/plot/...,gonum.org/v1/gonum/...,go-hep.org/x/hep/csvutil/...,go-hep.org/x/hep/fit,go-hep.org/x/hep/hbook \
+    && go get gonum.org/v1/plot/... \
+    && go get gonum.org/v1/gonum/... \
+    && go get github.com/go-gota/gota/... \
     && go get github.com/sajari/regression \
     && go get github.com/sjwhitworth/golearn/... \
-    && go get -insecure go-hep.org/x/hep/csvutil/... \
-    && go get -insecure go-hep.org/x/hep/fit \
-    && go get -insecure go-hep.org/x/hep/hbook \
+    && go get go-hep.org/x/hep/csvutil/... \
+    && go get go-hep.org/x/hep/fit \
+    && go get go-hep.org/x/hep/hbook \
     && go get github.com/montanaflynn/stats \
     && go get github.com/boltdb/bolt \
     && go get github.com/patrickmn/go-cache \
@@ -64,7 +69,7 @@ RUN set -x \
     && go get github.com/pkg/errors \
     && go get github.com/stretchr/testify/assert \
     ## clean
-    && find /usr/lib/python3.6 -name __pycache__ | xargs rm -r \
+    && find /usr/lib/python3.9 -name __pycache__ | xargs rm -r \
     && rm -rf \
         /root/.[acpw]* \
         ipaexg00301* \


### PR DESCRIPTION
As shown in Issue #201 , the bug is in the docker container for data science, when we try to convert some columns' data types, it shows `reflect.Value.Convert: value of type reflect.Value cannot be converted to type series.Type`.

We identified that the bug is from the go package `kniren/gota`. But the package `go-gota/gota` can work well. So I modified the Dockerfile.DS to replace `kniren/gota` with `go-gota/gota`.

Also, I updated the Alpine image version and some pre-installed packages and software which solves the cyclic imports error in issue #233 .